### PR TITLE
fix: Spring Boot 버전 변경 (3.0.0 -> 2.7.6)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.0.0'
+    id 'org.springframework.boot' version '2.7.6'
     id 'io.spring.dependency-management' version '1.1.0'
 }
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '17'
+sourceCompatibility = '11'
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
- Spring Boot 3.0 버전 이상 부터는 Java 17 이상 사용해야 함
- Spring Boot 버전 낮춤 (3.0.0 -> 2.7.6)